### PR TITLE
壊れる壁で爆風を止める

### DIFF
--- a/main.js
+++ b/main.js
@@ -106,7 +106,6 @@ function onPaint ()
             if (map.isInsideWall(me.gX,me.gY,map.bombermap)){me.gY -= gKey[83] * me.gS}
             
             //スペースキーが押し込まれたらボムを置く
-            console.log(spaceTime)
             if(spaceTime>0){
                 spaceTime--;
             }
@@ -118,7 +117,7 @@ function onPaint ()
         }
         
         //タイマー進める
-        me.bTimer();
+        me.bTimer(map.bombermap);
 
         draw();
     }
@@ -159,9 +158,10 @@ function draw()
             if(Math.round(me.gY/squareSize) == me.blastYX[i][0] && Math.round(me.gX/squareSize) == me.blastYX[i][1]) {
                 me.operable = 0;
             }
-            //ボムの爆風の長さの限り上下左右に爆風が伸びてゆく（）
-            //上
-            for(var r=1; r<=me.bRange; r++) {
+            
+            //ボムの爆風の長さの限り上下左右に爆風が伸びてゆく
+            //左
+            for(var r=1; r<=me.blastRange[i][0]; r++) {
                 if(map.bombermap[me.blastYX[i][0]][me.blastYX[i][1]-r] == 0) {
                     g.drawImage(blast, (me.blastYX[i][1]-r)*squareSize, me.blastYX[i][0]*squareSize, squareSize, squareSize)
                     //死亡判定
@@ -175,8 +175,8 @@ function draw()
                     break
                 }
             }
-            for(var r=1; r<=me.bRange; r++) {
-                //下
+            //右
+            for(var r=1; r<=me.blastRange[i][1]; r++) {
                 if(map.bombermap[me.blastYX[i][0]][me.blastYX[i][1]+r] == 0) {
                     g.drawImage(blast, (me.blastYX[i][1]+r)*squareSize, me.blastYX[i][0]*squareSize, squareSize, squareSize)
                     //死亡判定
@@ -190,8 +190,8 @@ function draw()
                     break
                 }
             }
-            for(var r=1; r<=me.bRange; r++) {
-                //左
+            //上
+            for(var r=1; r<=me.blastRange[i][2]; r++) {
                 if(map.bombermap[me.blastYX[i][0]-r][me.blastYX[i][1]] == 0) {
                     g.drawImage(blast, me.blastYX[i][1]*squareSize, (me.blastYX[i][0]-r)*squareSize, squareSize, squareSize)
                     //死亡判定
@@ -205,8 +205,8 @@ function draw()
                     break
                 }
             }
-            for(var r=1; r<=me.bRange; r++) {
-                //右
+            //下
+            for(var r=1; r<=me.blastRange[i][3]; r++) {
                 if(map.bombermap[me.blastYX[i][0]+r][me.blastYX[i][1]] == 0) {
                     g.drawImage(blast, me.blastYX[i][1]*squareSize, (me.blastYX[i][0]+r)*squareSize, squareSize, squareSize)
                     //死亡判定

--- a/player.js
+++ b/player.js
@@ -12,7 +12,7 @@ class Player{
     bLimit = 3; //爆弾を置ける最大数
     bCount = 0; //爆弾を置いている数
 
-    bRange = 4; //爆風の長さ
+    bRange = 2; //爆風の長さ
 
     bYX = [[],[],[],[],[],[],[],[],[],[]];  //爆弾一つ一つの座標を記録（最大10）
     bTime = [0,0,0,0,0,0,0,0,0,0];    //爆弾一つ一つの時間を管理する
@@ -20,6 +20,7 @@ class Player{
 
     blastYX = [[],[],[],[],[],[],[],[],[],[]];  //爆風一つ一つの座標を記録
     blastTime = [0,0,0,0,0,0,0,0,0,0];
+    blastRange = [[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0]]; //各爆風の実際に描画する縦横の距離
 
     constructor(gn,gx,gy){
         this.gN = gn;
@@ -43,7 +44,7 @@ class Player{
     }
 
     //爆弾・爆風のタイマー管理
-    bTimer() {
+    bTimer(m) {
         //置いている爆弾を探索し、その爆弾のタイマーを一律で減らしていく
         for(var i=0; i<this.bLimit;i++) {
             //爆弾が存在するならその爆弾のタイマーを減らす
@@ -60,6 +61,9 @@ class Player{
                     this.bYX[i] = [];
                     this.blastYX[i] = [y,x];
                     this.blastTime[i] = this.blastLimiter;
+
+                    //この段階で実際の爆風の距離を確定させる
+                    this.explotionRange(i,m)
                 }
             }
         }    
@@ -72,6 +76,7 @@ class Player{
                 if(this.blastTime[i] < 0) {
                     this.blastTime[i] = 0
                     this.blastYX[i] = [];
+                    this.blastRange[i] = [0,0,0,0];
                 }
             }
         }    
@@ -85,6 +90,38 @@ class Player{
             }    
         }
         return false
+    }
+
+    //実際の爆風の距離を計算
+    explotionRange (i, m){
+        //左
+        for(var r=1; r<=this.bRange; r++) {
+            this.blastRange[i][0] ++
+            if(m[this.blastYX[i][0]][this.blastYX[i][1]-r] != 0) {
+                break
+            }
+        }
+        //右
+        for(var r=1; r<=this.bRange; r++) {
+            this.blastRange[i][1] ++
+            if(m[this.blastYX[i][0]][this.blastYX[i][1]+r] != 0) {
+                break
+            }
+        }
+        //上
+        for(var r=1; r<=this.bRange; r++) {
+            this.blastRange[i][2] ++
+            if(m[this.blastYX[i][0]-r][this.blastYX[i][1]] != 0) {
+                break
+            }
+        }
+        //下
+        for(var r=1; r<=this.bRange; r++) {
+            this.blastRange[i][3] ++
+            if(m[this.blastYX[i][0]+r][this.blastYX[i][1]] != 0) {
+                break
+            }
+        }
     }
 
 }


### PR DESCRIPTION
壊れる壁のあるところで爆風を止めるようにしました。
爆発の起こったタイミング（bTimerの爆発ifに引っ掛かった時）に、実際に描画する爆風の上下左右の長さをそれぞれ先に計算して、新しい配列（blastRange）に、爆発の持続時間中だけ入れておくことで、解決しました。